### PR TITLE
fix vmf save for source io outputs

### DIFF
--- a/libs/entitylib.h
+++ b/libs/entitylib.h
@@ -522,6 +522,9 @@ public:
 		{
 			insert( key.c_str(), value->c_str() );
 		}
+		for ( const auto& output : other.m_outputs ) {
+			m_outputs.push_back( output);
+		}
 	}
 	~EntityKeyValues(){
 		for ( Observers::iterator i = m_observers.begin(); i != m_observers.end(); )
@@ -622,8 +625,25 @@ public:
 		}
 	}
 	void setKeyValue( const char* key, const char* value ) override {
+		if (string_equal_prefix( key, "On") ) {
+			erase( key ); // drop the legacy keyvalue
+			if ( string_empty( value ) ) {
+				for (auto it = m_outputs.begin(); it != m_outputs.end(); ) {
+					if (string_equal( it->key().c_str(), key ) ) {
+						it = m_outputs.erase( it );
+					} else {
+						++it;
+					}
+				}
+			} else {
+				addOutput( key, value );
+			}
+			m_entityKeyValueChanged();
+			return;
+		}
+
 		if ( string_empty( value )
-		     /*|| string_equal( EntityClass_valueForKey( *m_eclass, key ), value )*/ ) { // don't delete values equal to default
+		    /*|| string_equal( EntityClass_valueForKey( *m_eclass, key ), value )*/ ) { // don't delete values equal to default
 			erase( key );
 		}
 		else


### PR DESCRIPTION
this change routes On* keys into the entity outputs list so vmf save writes them under connections without merging duplicates. it also copies outputs when duplicating entities so they persist on save.

test: i loaded a basic test vmf with two entities with multiple OnTriggers each into source radiant, with the entity data looking like this in the vmf:
```
entity
{
	"id" "101"
	"classname" "logic_relay"
	"targetname" "test_relay"
	"OnTrigger" "target1,Trigger,,0,-1"
	"OnTrigger" "target2,Trigger,,0.5,-1"
	"OnTrigger" "target3,Trigger,,1,-1"
	"OnSpawn" "target1,Enable,,0,-1"
	"OnSpawn" "target2,Enable,,0,-1"
}
entity
{
	"id" "102"
	"classname" "trigger_once"
	"targetname" "test_trigger"
	"origin" "128 0 32"
	"OnTrigger" "test_relay,Trigger,,0,-1"
	"OnTrigger" "!activator,SetHealth,100,0,-1"
}
```

and after saving with source radiant:

```
"entity"
{
	"id" "45"
	"classname" "logic_relay"
	"targetname" "test_relay"
	"connections"
	{
		"OnTrigger" "target1,Trigger,,0,-1"
		"OnTrigger" "target2,Trigger,,0.5,-1"
		"OnTrigger" "target3,Trigger,,1,-1"
		"OnSpawn" "target1,Enable,,0,-1"
		"OnSpawn" "target2,Enable,,0,-1"
	}
}
"entity"
{
	"id" "46"
	"classname" "trigger_once"
	"targetname" "test_trigger"
	"origin" "128 0 32"
	"connections"
	{
		"OnTrigger" "test_relay,Trigger,,0,-1"
		"OnTrigger" "!activator,SetHealth,100,0,-1"
	}
}
```
the entities get their id's renamed but i think thats just because i made the original test.vmf file in a textfile instead of hammer.

the test map also compiled successfully and i was able to load in gmod just fine.
