### PR TITLE
Add Hotspot Texturing

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -6,6 +6,8 @@ LGPL - GNU Lesser General Public License v2.1
 ( see LGPL at the root of the tree )
 GPL - GNU General Public License v2
 ( see GPL at the root of the tree )
+MPL2 - Mozilla Public License Version 2.0
+( see MPL2 at the root of the tree )
 
 How do I check which license applies to a given part of the source code?
 
@@ -31,3 +33,6 @@ PrtView Plugin
 LGPL
 BobToolz Plugin
 GenSurf Plugin
+
+MPL2
+WifeRadiant Hotspot code

--- a/MPL2
+++ b/MPL2
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ WifeRadiant is a fork of NetRadiant-custom ([GtkRadiant](https://icculus.org/gtk
 - [GtkRadiant](https://icculus.org/gtkradiant/)
 - [FTEQW](https://github.com/fte-team/fteqw)
 - [Sean Barrett](https://github.com/nothings/stb)
+- [Hammer-Hotspots](https://github.com/koerismo/Hammer-Hotspots)
 
 ## Supported games
 
@@ -125,12 +126,12 @@ WifeRadiant is a fork of NetRadiant-custom ([GtkRadiant](https://icculus.org/gtk
 - Support rendering images and `.spr` files as sprites in-editor
 - ~~Add shader directory exclusion stuff to hide `models` directory~~
 	- ~~Respect `@MaterialExclusion` in FGDs~~
-- Hotspot texturing
-	- [https://developer.valvesoftware.com/wiki/Hotspot_texturing](https://developer.valvesoftware.com/wiki/Hotspot_texturing)
-	- [https://github.com/koerismo/Hammer-Hotspots](https://github.com/koerismo/Hammer-Hotspots)
-	- [https://wiki.stratasource.org/modding/formats/vtf-hotspot-resource](https://wiki.stratasource.org/modding/formats/vtf-hotspot-resource)
-	- [https://wiki.stratasource.org/modding/formats/vtf-hotspot-text-format](https://wiki.stratasource.org/modding/formats/vtf-hotspot-text-format)
-	- sourcepp supports `.hot` files and VTF hotspot resources
+- ~~Hotspot texturing~~
+	- ~~[https://developer.valvesoftware.com/wiki/Hotspot_texturing](https://developer.valvesoftware.com/wiki/Hotspot_texturing)~~
+	- ~~[https://github.com/koerismo/Hammer-Hotspots](https://github.com/koerismo/Hammer-Hotspots)~~
+	- ~~[https://wiki.stratasource.org/modding/formats/vtf-hotspot-resource](https://wiki.stratasource.org/modding/formats/vtf-hotspot-resource)~~
+	- ~~[https://wiki.stratasource.org/modding/formats/vtf-hotspot-text-format](https://wiki.stratasource.org/modding/formats/vtf-hotspot-text-format)~~
+	- ~~sourcepp supports `.hot` files and VTF hotspot resources~~
 
 ### Random feature highlights
 

--- a/include/ihotspot.h
+++ b/include/ihotspot.h
@@ -1,0 +1,123 @@
+/*
+   Copyright (C) 2025, Baguettery.
+   Copyright (C) 2026, erysdren (it/its).
+
+   This Source Code Form is subject to the terms of the
+   Mozilla Public License, v. 2.0. If a copy of the MPL
+   was not distributed with this file, You can obtain one
+   at https://mozilla.org/MPL/2.0/.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <cfloat>
+#include <vector>
+#include "math/vector.h"
+
+class HotSpotDef {
+public:
+	/// If any other rects are within this threshold,
+	/// they should be used to randomize the result.
+	const float aspectErrorMargin = 0.02f;
+
+	// (1.0 = allow 2x bigger or 2x smaller textures)
+	const float scaleErrorMargin = 0.20f;
+
+	struct Vec2 {
+		uint16_t x, y;
+	};
+
+	struct Rect {
+		enum Flags : uint8_t {
+			EnableRotation = 1 << 0,
+			EnableReflection = 1 << 1,
+			EnableTiling = 1 << 2,
+			AltGroup = 1 << 3
+		};
+		Vec2 mins, maxs;
+		uint8_t flags;
+
+		bool CanRotate() const {
+			return this->flags & static_cast<uint8_t>(Flags::EnableRotation);
+		}
+		bool CanReflect() const {
+			return this->flags & static_cast<uint8_t>(Flags::EnableReflection);
+		}
+		bool CanTile() const {
+			return this->flags & static_cast<uint8_t>(Flags::EnableTiling);
+		}
+		bool IsAltGroup() const {
+			return this->flags & static_cast<uint8_t>(Flags::AltGroup);
+		}
+	};
+
+	Vec2 size;
+	std::vector<Rect> rects;
+
+	int MatchRandomBestRect(float targetAspect, float targetScale, bool altGroup, bool* out_isRotated, float* out_aspectErr, float* out_scalingErr) const {
+		if (this->rects.empty()) return -1;
+		float logTargetScale = std::log2f(targetScale);
+
+		std::size_t rectCount = this->rects.size();
+		std::vector<bool> rectsRotated(rectCount);
+		std::vector<float> aspectErrors(rectCount);
+		std::vector<float> scaleErrors(rectCount);
+		float bestAspectError = INFINITY;
+
+		// Calculate the aspect ratio and scaling errors of each rect
+		for (std::size_t i = 0; i < rectCount; i++) {
+			Rect rect = this->rects[i];
+			if (rect.IsAltGroup() != altGroup) continue;
+			float width = static_cast<float>(rect.maxs.x - rect.mins.x);
+			float height = static_cast<float>(rect.maxs.y - rect.mins.y);
+			float maxDim = (width > height ? width : height);
+			if (height < FLT_EPSILON || width < FLT_EPSILON) continue;
+
+			float aspect = width / height;
+			rectsRotated[i] = rect.CanRotate() && ((aspect > 1) != (targetAspect > 1));
+			if (rectsRotated[i]) aspect = 1.0f / aspect;
+
+			float aspectError = fabs(aspect - targetAspect);
+			aspectErrors[i] = aspectError;
+			scaleErrors[i] = fabs(std::log2f(maxDim) - logTargetScale);
+			if (aspectError < bestAspectError) bestAspectError = aspectError;
+		}
+
+		std::vector<int> aspectMatches;
+		float bestScaleError = INFINITY;
+
+		// Pick only the best aspect matches within an error margin
+		for (std::size_t i = 0; i < rectCount; i++) {
+			if (this->rects[i].IsAltGroup() != altGroup) continue;
+			if (aspectErrors[i] > bestAspectError + aspectErrorMargin) continue;
+			if (scaleErrors[i] < bestScaleError) bestScaleError = scaleErrors[i];
+			aspectMatches.push_back(i);
+		}
+
+		std::vector<int> finalMatches;
+
+		// Pick only the best scaling matches within an error margin
+		for (std::size_t i = 0; i < aspectMatches.size(); i++) {
+			if (scaleErrors[aspectMatches[i]] > bestScaleError + scaleErrorMargin) continue;
+			finalMatches.push_back(aspectMatches[i]);
+		}
+
+		if (finalMatches.size() == 0) return -1;
+		int result = finalMatches[std::rand() % finalMatches.size()];
+
+		if (out_isRotated != NULL) *out_isRotated = rectsRotated[result];
+		if (out_aspectErr != NULL) *out_aspectErr = aspectErrors[result];
+		if (out_scalingErr != NULL) *out_scalingErr = scaleErrors[result];
+		return result;
+	}
+
+	void GetUvMinMax(int i, std::size_t width, std::size_t height, Vector2* vMins, Vector2* vMaxs) const {
+		const Rect* rect = &this->rects[i];
+		vMins->x() = static_cast<float>(rect->mins.x) / static_cast<float>(width);
+		vMins->y() = static_cast<float>(rect->mins.y) / static_cast<float>(height);
+		vMaxs->x() = static_cast<float>(rect->maxs.x) / static_cast<float>(width);
+		vMaxs->y() = static_cast<float>(rect->maxs.y) / static_cast<float>(height);
+		return;
+	}
+};

--- a/include/ishaders.h
+++ b/include/ishaders.h
@@ -23,6 +23,7 @@
 
 #include "generic/constant.h"
 #include "generic/callback.h"
+#include "ihotspot.h"
 
 enum
 {
@@ -125,6 +126,8 @@ public:
 	virtual void forEachLayer( const ShaderLayerCallback& layer ) const = 0;
 
 	virtual qtexture_t* lightFalloffImage() const = 0;
+
+	virtual const HotSpotDef* getHotSpotDef() const = 0;
 };
 
 typedef Callback<void(const char*)> ShaderNameCallback;

--- a/modules/shaders/shaders.cpp
+++ b/modules/shaders/shaders.cpp
@@ -275,6 +275,7 @@ class ShaderTemplate
 {
 	std::size_t m_refcount;
 	CopiedString m_Name;
+	CopiedString m_hotSpotDefName;
 public:
 
 	ShaderParameters m_params;
@@ -323,6 +324,12 @@ public:
 		m_Name = name;
 	}
 
+	const char* getHotSpotDefName() const {
+		return m_hotSpotDefName.c_str();
+	}
+	void setHotSpotDefName( const char* name ){
+		m_hotSpotDefName = name;
+	}
 // -----------------------------------------
 
 	bool parseDoom3( Tokeniser& tokeniser );
@@ -599,6 +606,9 @@ bool ShaderTemplate::parseDoom3( Tokeniser& tokeniser ){
 			if ( string_equal_nocase( token, "qer_editorimage" ) ) {
 				RETURN_FALSE_IF_FAIL( Tokeniser_parseTextureName( tokeniser, m_textureName ) );
 			}
+			if ( string_equal_nocase( token, "qer_rectanglemap" ) ) {
+				RETURN_FALSE_IF_FAIL( Tokeniser_parseTextureName( tokeniser, m_hotSpotDefName ) );
+			}
 			else if ( string_equal_nocase( token, "qer_trans" ) ) {
 				m_fTrans = string_read_float( tokeniser.getToken() );
 				m_nFlags |= QER_TRANS;
@@ -778,6 +788,65 @@ qtexture_t* evaluateTexture( const TextureExpression& texture, const ShaderParam
 	return GlobalTexturesCache().capture( loader, result );
 }
 
+HotSpotDef* evaluateHotSpotDef( const char *textureName, const char *hotSpotDefName ){
+	ArchiveFile* f = nullptr;
+	if ( hotSpotDefName && !string_empty( hotSpotDefName ) ) {
+		f = GlobalFileSystem().openFile( hotSpotDefName );
+	}
+
+	if ( !f ) {
+		f = GlobalFileSystem().openFile( StringStream( PathCleaned( PathExtensionless( textureName ) ), ".rect" ) );
+	}
+
+	if ( !f ) {
+		return nullptr;
+	}
+
+	ScopedArchiveBuffer buffer(*f);
+	std::string_view kv1Data((char *)buffer.buffer, (char *)buffer.buffer + buffer.length);
+	kvpp::KV1 kv1(kv1Data);
+	f->release();
+
+	std::vector<HotSpotDef::Rect> rects;
+
+	for ( auto& child : kv1[0] ) {
+		if ( !child["min"] || !child["max"] ) {
+			globalErrorStream() << "rectanglemap " << Quoted( f->getName() ) << " has bad rectangle definition" << '\n';
+			return nullptr;
+		}
+		HotSpotDef::Rect rect{};
+		char *ptr = NULL;
+		rect.mins.x = std::strtoul(child["min"].getValue().data(), &ptr, 10);
+		rect.mins.y = std::strtoul(ptr, &ptr, 10);
+		rect.maxs.x = std::strtoul(child["max"].getValue().data(), &ptr, 10);
+		rect.maxs.y = std::strtoul(ptr, &ptr, 10);
+		if ( child["rotate"] && child["rotate"].getValue<bool>() ) {
+			rect.flags |= static_cast<uint8_t>(HotSpotDef::Rect::Flags::EnableRotation);
+		}
+		if ( child["reflect"] && child["reflect"].getValue<bool>() ) {
+			rect.flags |= static_cast<uint8_t>(HotSpotDef::Rect::Flags::EnableReflection);
+		}
+		if ( child["tile"] && child["tile"].getValue<bool>() ) {
+			rect.flags |= static_cast<uint8_t>(HotSpotDef::Rect::Flags::EnableTiling);
+		}
+		if ( child["alt"] && child["alt"].getValue<bool>() ) {
+			rect.flags |= static_cast<uint8_t>(HotSpotDef::Rect::Flags::AltGroup);
+		}
+		rects.push_back(rect);
+	}
+
+	if ( rects.empty() ) {
+		globalErrorStream() << "rectanglemap " << Quoted( f->getName() ) << " has no rectangle definitions" << '\n';
+		return nullptr;
+	}
+
+	HotSpotDef* hotspotDef = new HotSpotDef;
+
+	hotspotDef->rects.assign(rects.begin(), rects.end());
+
+	return hotspotDef;
+}
+
 float evaluateFloat( const ShaderValue& value, const ShaderParameters& params, const ShaderArguments& args ){
 	const char* result = evaluateShaderValue( value.c_str(), params, args );
 	float f;
@@ -848,6 +917,7 @@ class CShader final : public IShader
 	qtexture_t* m_pSpecular;
 	qtexture_t* m_pLightFalloffImage;
 	BlendFunc m_blendFunc;
+	HotSpotDef* m_hotSpotDef;
 
 	bool m_bInUse;
 
@@ -867,6 +937,7 @@ public:
 		m_pDiffuse = 0;
 		m_pBump = 0;
 		m_pSpecular = 0;
+		m_hotSpotDef = 0;
 
 		m_notfound = 0;
 
@@ -967,6 +1038,8 @@ public:
 			m_pTexture = GlobalTexturesCache().capture( LoadImageCallback( 0, loadBitmap ), name );
 		}
 
+		m_hotSpotDef = evaluateHotSpotDef( m_template.m_textureName.c_str(), m_template.getHotSpotDefName() );
+
 		realiseLighting();
 	}
 
@@ -979,6 +1052,10 @@ public:
 
 		if ( m_pSkyBox != 0 ) {
 			GlobalTexturesCache().release( m_pSkyBox );
+		}
+
+		if ( m_hotSpotDef != 0 ) {
+			delete m_hotSpotDef;
 		}
 
 		unrealiseLighting();
@@ -1112,6 +1189,10 @@ public:
 		}
 		return 0;
 	}
+
+	const HotSpotDef* getHotSpotDef() const override {
+		return m_hotSpotDef;
+	}
 };
 
 bool CShader::m_lightingEnabled = false;
@@ -1202,6 +1283,9 @@ bool ShaderTemplate::parseQuake3( Tokeniser& tokeniser ){
 			}
 			else if ( string_equal_nocase( token, "qer_editorimage" ) ) {
 				RETURN_FALSE_IF_FAIL( Tokeniser_parseTextureName( tokeniser, m_textureName ) );
+			}
+			else if ( string_equal_nocase( token, "qer_rectanglemap" ) ) {
+				RETURN_FALSE_IF_FAIL( Tokeniser_parseTextureName( tokeniser, m_hotSpotDefName ) );
 			}
 			else if ( string_equal_nocase( token, "qer_alphafunc" ) ) {
 				const char* alphafunc = tokeniser.getToken();
@@ -1533,6 +1617,11 @@ void ParseSourceShaderFile( ArchiveFile* file, const char* filename ){
 	if ( kv1[0]["$nocull"] ) {
 		shaderTemplate->m_Cull = IShader::eCullNone;
 		shaderTemplate->m_nFlags |= QER_CULL;
+	}
+
+	if ( kv1[0]["%rectanglemap"] ) {
+		std::string hotSpotDefName = std::format("materials/{}.rect", kv1[0]["%rectanglemap"].getValue());
+		shaderTemplate->setHotSpotDefName(hotSpotDefName.c_str());
 	}
 
 	g_shaderDefinitions.insert( ShaderDefinitionMap::value_type( shaderTemplate->getName(), ShaderDefinition( shaderTemplate.get(), ShaderArguments(), filename ) ) );

--- a/radiant/brush.h
+++ b/radiant/brush.h
@@ -44,6 +44,7 @@
 #include "ifilter.h"
 #include "nameable.h"
 #include "moduleobserver.h"
+#include "ihotspot.h"
 
 #include "cullable.h"
 #include "renderable.h"
@@ -567,6 +568,10 @@ public:
 
 	void fit( const Vector3& normal, const Winding& winding, float s_repeat, float t_repeat, bool only_dimension ){
 		Texdef_FitTexture( m_projection, m_shader.width(), m_shader.height(), normal, winding, s_repeat, t_repeat, only_dimension );
+	}
+
+	void fitHotSpot( const Vector3& normal, const Winding& winding, const HotSpotDef* hotSpotDef, bool altGroup ){
+		Texdef_FitTextureHotSpot( m_projection, m_shader.width(), m_shader.height(), normal, winding, hotSpotDef, altGroup );
 	}
 
 	void emitTextureCoordinates( Winding& winding, const Vector3& normal, const Matrix4& localToWorld ) const {
@@ -1274,6 +1279,12 @@ public:
 	void FitTexture( float s_repeat, float t_repeat, bool only_dimension ){
 		undoSave();
 		m_texdef.fit( m_plane.plane3().normal(), m_winding, s_repeat, t_repeat, only_dimension );
+		texdefChanged();
+	}
+
+	void FitTextureHotspot( const HotSpotDef* hotSpotDef, bool altGroup ){
+		undoSave();
+		m_texdef.fitHotSpot( m_plane.plane3().normal(), m_winding, hotSpotDef, altGroup );
 		texdefChanged();
 	}
 

--- a/radiant/brush_primit.cpp
+++ b/radiant/brush_primit.cpp
@@ -1280,6 +1280,73 @@ void Texdef_FitTexture( TextureProjection& projection, std::size_t width, std::s
 		Texdef_normalise( projection.m_texdef, width, height );
 }
 
+void Texdef_FitTextureHotSpot( TextureProjection& projection, std::size_t width, std::size_t height, const Vector3& normal, const Winding& w, const HotSpotDef* hotSpotDef, bool altGroup ){
+	if ( w.numpoints < 3 ) {
+		return;
+	}
+
+	Matrix4 st2tex;
+	Texdef_toTransform( projection, width, height, st2tex );
+
+	// the current texture transform
+	Matrix4 local2tex = st2tex;
+	{
+		Matrix4 xyz2st;
+		Texdef_basisForNormal( projection, normal, xyz2st );
+		matrix4_multiply_by_matrix4( local2tex, xyz2st );
+	}
+
+	// the bounds of the current texture transform
+	AABB bounds;
+	for ( const auto& v : w )
+	{
+		Vector3 texcoord = matrix4_transformed_point( local2tex, v.vertex );
+		aabb_extend_by_point_safe( bounds, texcoord );
+	}
+	bounds.origin.z() = 0;
+	bounds.extents.z() = 1;
+
+	Vector2 mins = Vector2(bounds.origin.x(), bounds.origin.y()) - Vector2(bounds.extents.x(), bounds.extents.y());
+	Vector2 maxs = Vector2(bounds.origin.x(), bounds.origin.y()) + Vector2(bounds.extents.x(), bounds.extents.y());
+
+	Vector2 size = maxs - mins;
+
+	const float targetScale = std::max(width * size.x(), height * size.y()) / Texdef_getDefaultTextureScale();
+	const float targetAspect = size.x() / size.y();
+
+	bool isRotated = false;
+	float aspectErr = -1;
+	float scalingErr = -1;
+	int rectIndex = hotSpotDef->MatchRandomBestRect(targetAspect, targetScale, altGroup, &isRotated, &aspectErr, &scalingErr);
+	if ( rectIndex < 0 ) {
+		rectIndex = hotSpotDef->MatchRandomBestRect(targetAspect, targetScale, false, &isRotated, &aspectErr, &scalingErr);
+	}
+	if ( rectIndex < 0 ) {
+		globalErrorStream() << "failed to match best rect!" << '\n';
+		return;
+	}
+
+	// globalOutputStream() << std::format("Chose rectangle {} (rotated={}) with a diff of an aspectErr of {} and scalingErr of {}", rectIndex, isRotated, aspectErr, scalingErr) << '\n';
+
+	Vector2 uvMins, uvMaxs;
+	hotSpotDef->GetUvMinMax(rectIndex, width, height, &uvMins, &uvMaxs);
+
+	AABB perfect = aabb_for_minmax(Vector3(uvMins.x(), uvMins.y(), -1), Vector3(uvMaxs.x(), uvMaxs.y(), 1));
+
+	// the difference between the current texture transform and the perfectly fitted transform
+	Matrix4 matrix( matrix4_translation_for_vec3( bounds.origin - perfect.origin ) );
+	matrix4_pivoted_scale_by_vec3( matrix, bounds.extents / perfect.extents, perfect.origin );
+	matrix4_affine_invert( matrix );
+
+	// apply the difference to the current texture transform
+	matrix4_premultiply_by_matrix4( st2tex, matrix );
+	Texdef_fromTransform( projection, width, height, st2tex );
+	if ( g_bp_globals.m_texdefTypeId == TEXDEFTYPEID_BRUSHPRIMITIVES )
+		BPTexdef_normalise( projection.m_brushprimit_texdef, 1, 1 ); /* scaleApplied is! */
+	else
+		Texdef_normalise( projection.m_texdef, width, height );
+}
+
 float Texdef_getDefaultTextureScale(){
 	return g_texdef_default_scale;
 }

--- a/radiant/brush_primit.h
+++ b/radiant/brush_primit.h
@@ -23,6 +23,7 @@
 
 #include "math/vector.h"
 #include "itexdef.h"
+#include "ihotspot.h"
 #include "debugging/debugging.h"
 // Timo
 // new brush primitive texdef
@@ -103,6 +104,7 @@ void Texdef_Rotate( TextureProjection& projection, float angle );
 void Texdef_ProjectTexture( TextureProjection& projection, std::size_t width, std::size_t height, const Plane3& plane, const texdef_t& texdef, const Vector3* direction );
 void Texdef_ProjectTexture( TextureProjection& projection, std::size_t width, std::size_t height, const Plane3& plane, TextureProjection other_proj, const Vector3& other_normal );
 void Texdef_FitTexture( TextureProjection& projection, std::size_t width, std::size_t height, const Vector3& normal, const Winding& w, float s_repeat, float t_repeat, bool only_dimension );
+void Texdef_FitTextureHotSpot( TextureProjection& projection, std::size_t width, std::size_t height, const Vector3& normal, const Winding& w, const HotSpotDef* hotSpotDef, bool altGroup );
 void Texdef_Construct_local2tex( const TextureProjection& projection, std::size_t width, std::size_t height, const Vector3& normal, Matrix4& local2tex );
 void Texdef_Construct_local2tex4projection( const texdef_t& texdef, std::size_t width, std::size_t height, const Vector3& normal, const Vector3* direction, Matrix4& local2tex );
 void Texdef_Construct_local2tex_from_ST( const PlanePoints& points, const DoubleVector3 st[3], Matrix4& local2tex );

--- a/radiant/brushmanip.cpp
+++ b/radiant/brushmanip.cpp
@@ -33,6 +33,7 @@
 #include "dialog.h"
 #include "xywindow.h"
 #include "preferences.h"
+#include "ihotspot.h"
 
 void Brush_ConstructCuboid( Brush& brush, const AABB& bounds, const char* shader, const TextureProjection& projection ){
 	const unsigned char box[3][2] = { { 0, 1 }, { 2, 0 }, { 1, 2 } };
@@ -794,6 +795,39 @@ void Scene_BrushFitTexture_Selected( scene::Graph& graph, float s_repeat, float 
 
 void Scene_BrushFitTexture_Component_Selected( scene::Graph& graph, float s_repeat, float t_repeat, bool only_dimension ){
 	Scene_ForEachSelectedBrushFace( graph, FaceFitTexture( s_repeat, t_repeat, only_dimension ) );
+	SceneChangeNotify();
+}
+
+
+class FaceFitTextureHotspot
+{
+	bool m_altGroup;
+public:
+	FaceFitTextureHotspot( bool altGroup ) : m_altGroup( altGroup ) {
+	}
+	void operator()( Face& face ) const {
+		IShader* shader = GlobalShaderSystem().getShaderForName( face.GetShader() );
+		if ( !shader ) {
+			globalErrorStream() << "failed to find shader by the name: " << Quoted( face.GetShader() ) << '\n';
+			return;
+		}
+		const auto* hotSpotDef = shader->getHotSpotDef();
+		if ( hotSpotDef ) {
+			face.FitTextureHotspot( hotSpotDef, m_altGroup );
+		} else {
+			// globalWarningStream() << Quoted( face.GetShader() ) << " has no hotspots defined" << '\n';
+		}
+		shader->DecRef();
+	}
+};
+
+void Scene_BrushFitTextureHotspot_Selected( scene::Graph& graph, bool altGroup ){
+	Scene_ForEachSelectedBrush_ForEachFace( graph, FaceFitTextureHotspot( altGroup ) );
+	SceneChangeNotify();
+}
+
+void Scene_BrushFitTextureHotspot_Component_Selected( scene::Graph& graph, bool altGroup ){
+	Scene_ForEachSelectedBrushFace( graph, FaceFitTextureHotspot( altGroup ) );
 	SceneChangeNotify();
 }
 

--- a/radiant/brushmanip.h
+++ b/radiant/brushmanip.h
@@ -84,6 +84,9 @@ void Scene_BrushProjectTexture_Component_Selected( scene::Graph& graph, const Te
 void Scene_BrushFitTexture_Selected( scene::Graph& graph, float s_repeat, float t_repeat, bool only_dimension );
 void Scene_BrushFitTexture_Component_Selected( scene::Graph& graph, float s_repeat, float t_repeat, bool only_dimension );
 
+void Scene_BrushFitTextureHotspot_Selected( scene::Graph& graph, bool altGroup );
+void Scene_BrushFitTextureHotspot_Component_Selected( scene::Graph& graph, bool altGroup );
+
 void Brush_constructMenu( class QMenu* menu );
 
 extern Callback<void()> g_texture_lock_status_changed;

--- a/radiant/select.cpp
+++ b/radiant/select.cpp
@@ -932,6 +932,14 @@ void Select_FitTexture( float horizontal, float vertical, bool only_dimension ){
 	SceneChangeNotify();
 }
 
+void Select_FitTextureHotspot( bool altGroup ){
+	if ( GlobalSelectionSystem().Mode() != SelectionSystem::eComponent ) {
+		Scene_BrushFitTextureHotspot_Selected( GlobalSceneGraph(), altGroup );
+	}
+	Scene_BrushFitTextureHotspot_Component_Selected( GlobalSceneGraph(), altGroup );
+	SceneChangeNotify();
+}
+
 
 #include "commands.h"
 #include "dialog.h"

--- a/radiant/select.h
+++ b/radiant/select.h
@@ -47,6 +47,7 @@ void Select_SetFlags( const class ContentsFlagsValue& flags );
 void Select_ProjectTexture( const class texdef_t& texdef, const Vector3* direction );
 void Select_ProjectTexture( const class TextureProjection& projection, const Vector3& normal );
 void Select_FitTexture( float horizontal = 1, float vertical = 1, bool only_dimension = false );
+void Select_FitTextureHotspot( bool altGroup );
 void FindReplaceTextures( const char* pFind, const char* pReplace, bool bSelected );
 
 void Select_ShowAllHidden();

--- a/radiant/surfacedialog.cpp
+++ b/radiant/surfacedialog.cpp
@@ -443,9 +443,16 @@ void SurfaceInspector_InvertTextureVertically(){
 
 
 void SurfaceInspector_FitTexture(){
-	UndoableCommand undo( "textureAutoFit" );
-	getSurfaceInspector().exportData();
-	Select_FitTexture( getSurfaceInspector().m_fitHorizontal, getSurfaceInspector().m_fitVertical );
+	auto keyboardModifiers = QGuiApplication::keyboardModifiers();
+	if (keyboardModifiers & Qt::ShiftModifier) {
+		UndoableCommand undo( "textureAutoFitHotSpot" );
+		getSurfaceInspector().exportData();
+		Select_FitTextureHotspot( keyboardModifiers & Qt::AltModifier );
+	} else {
+		UndoableCommand undo( "textureAutoFit" );
+		getSurfaceInspector().exportData();
+		Select_FitTexture( getSurfaceInspector().m_fitHorizontal, getSurfaceInspector().m_fitVertical );
+	}
 }
 
 void SurfaceInspector_FaceFitWidth(){


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the WifeRadiant project under the GPLv2 license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
- adds hotspot texturing, based on [Hammer-Hotspots](https://github.com/koerismo/Hammer-Hotspots/)
- adds MPL2 license document for the hotspot-specific code
- currently **does not** load hotspot VTF resources, but does load `.rect` files specified in VMTs,  Q3/D3 shaders, and as a fallback tries to load it from `${texturename}.rect`. 

to specify a `.rect` file in a Quake 3 or DOOM 3 shader, use the `qer_rectanglemap` key with the value being the path to the `.rect` file (including extension) relative to the game directory.

example:
```
textures/hotspot_example
{
    qer_rectanglemap textures/hotspot_example.rect
    {
        map textures/hotspot_example.tga
    }
    {
        map $lightmap
        blendfunc filter
    }
}
```